### PR TITLE
fix edge case where nix-search fails when $PAGER env var includes multiple arguments

### DIFF
--- a/cmd/nix-search/main.go
+++ b/cmd/nix-search/main.go
@@ -165,7 +165,15 @@ func mainAction(c *cli.Context) error {
 			pager = "less"
 		}
 
-		pagerCmd := exec.CommandContext(ctx, pager)
+		var pagerCmd *exec.Cmd
+
+		psplit := strings.Split(pager, " ")
+		if len(psplit) > 1 {
+			pagerCmd = exec.CommandContext(ctx, psplit[0], psplit[1:]...)
+		} else {
+			pagerCmd = exec.CommandContext(ctx, pager)
+		}
+
 		pagerCmd.Stdout = os.Stdout
 		pagerCmd.Stderr = os.Stderr
 


### PR DESCRIPTION
nix-search fails when $PAGER includes more than one argument. for example:

```bash
$ nix-search "clang"
2024-07-06T20:16:52.134-0800 [ERROR] error: err="failed to start pager: exec: \"bat --color=always -p\": executable file not found in $PATH"

$ echo $PAGER
bat --color=always -p
````
this commit splits the PAGER env var string, checks the length of the string slice, and handles this case.